### PR TITLE
Upload Playwright test traces using Github Actions

### DIFF
--- a/.github/workflows/run-playwight-tests.yml
+++ b/.github/workflows/run-playwight-tests.yml
@@ -33,6 +33,7 @@ jobs:
         run: |
           ./run_e2e_tests.js
       - name: Archive trace artifacts
+        if: always()
         uses: actions/upload-artifact@v2
         with:
           name: Playwright test results

--- a/.github/workflows/run-playwight-tests.yml
+++ b/.github/workflows/run-playwight-tests.yml
@@ -35,5 +35,5 @@ jobs:
       - name: Archive trace artifacts
         uses: actions/upload-artifact@v2
         with:
-          name: Playwright traces
-          path: ./__tests__/playwright/traces
+          name: Playwright test results
+          path: test-results

--- a/__tests__/playwright/game-test.js
+++ b/__tests__/playwright/game-test.js
@@ -27,13 +27,7 @@ const {
 
 test.describe("game", () => {
   test.beforeEach(async ({ context, page }) => {
-    await context.tracing.start({ screenshots: true, snapshots: true });
     await loadPage(page);
-  });
-
-  test.afterEach(async ({ context }, { title }) => {
-    const path = join(__dirname, "traces", title.replace(/\s/g, "-") + ".zip");
-    await context.tracing.stop({ path });
   });
 
   test.describe("input", () => {

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -12,6 +12,7 @@ const config = {
 
   testDir: "__tests__/playwright",
   testMatch: "**/*-test.js",
+  outputDir: "test-results/",
 
   use: {
     // Uncomment for easier local debugging


### PR DESCRIPTION
Here's some changes that allow your Github Action to produce a .zip that contains a folder with screenshots, videos as well as traces for each test, without having to call the tracer functions in your tests :)

See https://github.com/rodymolenaar/turdle/actions/runs/1878338175